### PR TITLE
Add QEMU audio and relative mouse pointer pseudo-encodings + fixes & notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# vnc-rfb-client: ayunami2000's fork
+## includes support for:
+- qemu audio (PCM) (user customization (e.g. num channels, frequency) WIP)
+- qemu relative pointer (WIP)
+
+
+
+
 <!--
 *** Thanks for checking out the Best-README-Template. If you have a suggestion
 *** that would make this better, please fork the repo and create a pull request

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# vnc-rfb-client: ayunami2000's fork
-## includes support for:
-- qemu audio (PCM) (user customization (e.g. num channels, frequency) WIP)
-- qemu relative pointer
-
-
-
-
 <!--
 *** Thanks for checking out the Best-README-Template. If you have a suggestion
 *** that would make this better, please fork the repo and create a pull request
@@ -46,6 +38,12 @@
     <a href="https://github.com/filipecbmoc/vnc-rfb-client/issues">Report Bug or Request Feature</a>
   </p>
 </p>
+
+<!-- CONTRIBUTIONS -->
+## User Contributions
+### ayunami2000
+- qemu audio (PCM) (user customization (e.g. num channels, frequency) WIP)
+- qemu relative pointer
 
 
 <!-- GETTING STARTED -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vnc-rfb-client: ayunami2000's fork
 ## includes support for:
 - qemu audio (PCM) (user customization (e.g. num channels, frequency) WIP)
-- qemu relative pointer (WIP)
+- qemu relative pointer
 
 
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@
 <!-- CONTRIBUTIONS -->
 ## User Contributions
 ### ayunami2000
-- qemu audio (PCM) (user customization (e.g. num channels, frequency) WIP)
+- qemu audio (PCM)
 - qemu relative pointer
+- documentation for these WIP
 
 
 <!-- GETTING STARTED -->

--- a/constants.js
+++ b/constants.js
@@ -8,12 +8,14 @@ const consts = {
         keyEvent: 4,
         pointerEvent: 5,
         cutText: 6,
+        qemuAudio: 255,
     },
     serverMsgTypes: {
         fbUpdate: 0,
         setColorMap: 1,
         bell: 2,
         cutText: 3,
+        qemuAudio: 255,
     },
     versionString: {
         V3_003: 'RFB 003.003\n',
@@ -34,6 +36,8 @@ const consts = {
         h264: 50,
         pseudoCursor: -239,
         pseudoDesktopSize: -223,
+        pseudoQemuPointerMotionChange: -257,
+        pseudoQemuAudio: -259,
     },
     security: {
         None: 1,

--- a/vncclient.js
+++ b/vncclient.js
@@ -772,7 +772,7 @@ class VncClient extends Events {
     }
 
     clientAudio(enable) {
-        const message = new Buffer(8 + textBuffer.length);
+        const message = new Buffer(3);
         message.writeUInt8(clientMsgTypes.qemuAudio); // Message type
         message.writeUInt8(1, 1); // Submessage Type
         message.writeUInt16BE(enable?0:1, 2); // Operation
@@ -780,7 +780,7 @@ class VncClient extends Events {
     }
 
     clientAudioConfig(channels, frequency) {
-        const message = new Buffer(8 + textBuffer.length);
+        const message = new Buffer(10);
         message.writeUInt8(clientMsgTypes.qemuAudio); // Message type
         message.writeUInt8(1, 1); // Submessage Type
         message.writeUInt16BE(2, 2); // Operation

--- a/vncclient.js
+++ b/vncclient.js
@@ -523,7 +523,7 @@ class VncClient extends Events {
 
             if(rect.encoding === encodings.pseudoQemuAudio){
 				this.sendAudio(true);
-				this.sendAudioConfig(2,22500);//todo: add config values for changing this (future: setFrequency(...) to update mid thing)
+				this.sendAudioConfig(2,22050);//todo: add config values for changing this (future: setFrequency(...) to update mid thing)
 			} else if(rect.encoding === encodings.pseudoQemuPointerMotionChange){
 				console.log("HYPE: "+JSON.stringify(rect));
 			} else if (rect.encoding === encodings.pseudoCursor) {
@@ -614,7 +614,6 @@ class VncClient extends Events {
     }
 
     async _handleQemuAudio() {
-		console.log(1234);
         this._socketBuffer.setOffset(2);
         let operation = this._socketBuffer.readUInt16BE();
         if(operation==2){
@@ -791,7 +790,7 @@ class VncClient extends Events {
         message.writeUInt8(clientMsgTypes.qemuAudio); // Message type
         message.writeUInt8(1, 1); // Submessage Type
         message.writeUInt16BE(2, 2); // Operation
-        message.writeUInt8(4/*U32*/, 4); // Sample Format
+        message.writeUInt8(0/*U8*/, 4); // Sample Format
         message.writeUInt8(channels, 5); // Number of Channels
         message.writeUInt32BE(frequency, 6); // Frequency
         this._connection.write(message);

--- a/vncclient.js
+++ b/vncclient.js
@@ -1,4 +1,4 @@
-const {versionString, encodings, serverMsgTypes} = require('./constants');
+const {versionString, encodings, serverMsgTypes, clientMsgTypes} = require('./constants');
 const net = require('net');
 const Events = require('events').EventEmitter;
 

--- a/vncclient.js
+++ b/vncclient.js
@@ -525,7 +525,7 @@ class VncClient extends Events {
 				this.sendAudio(true);
 				this.sendAudioConfig(2,22050);//todo: add config values for changing this (future: setFrequency(...) to update mid thing)
 			} else if(rect.encoding === encodings.pseudoQemuPointerMotionChange){
-				console.log("HYPE: "+JSON.stringify(rect));
+				this._relativePointer=rect.x==0;
 			} else if (rect.encoding === encodings.pseudoCursor) {
                 const dataSize = rect.width * rect.height * (this.pixelFormat.bitsPerPixel / 8);
                 const bitmaskSize = Math.floor((rect.width + 7) / 8) * rect.height;
@@ -751,8 +751,9 @@ class VncClient extends Events {
         const message = new Buffer(6);
         message.writeUInt8(5); // Message type
         message.writeUInt8(buttonMask, 1); // Button Mask
-        message.writeUInt16BE(xPosition, 2); // X Position
-        message.writeUInt16BE(yPosition, 4); // Y Position
+        const reladd=this._relativePointer?0x7FFF:0;
+        message.writeUInt16BE(xPosition+reladd, 2); // X Position
+        message.writeUInt16BE(yPosition+reladd, 4); // Y Position
 
         this._connection.write(message);
 

--- a/vncclient.js
+++ b/vncclient.js
@@ -772,7 +772,7 @@ class VncClient extends Events {
     }
 
     clientAudio(enable) {
-        const message = new Buffer(3);
+        const message = new Buffer(4);
         message.writeUInt8(clientMsgTypes.qemuAudio); // Message type
         message.writeUInt8(1, 1); // Submessage Type
         message.writeUInt16BE(enable?0:1, 2); // Operation

--- a/vncclient.js
+++ b/vncclient.js
@@ -67,6 +67,9 @@ class VncClient extends Events {
             encodings.raw,
             encodings.pseudoDesktopSize
         ];
+	
+	this._audioChannels = options.audioChannels || 2;
+	this._audioFrequency = options.audioFrequency || 22050;
 
         this._rects = 0;
         this._decoders = {};
@@ -523,7 +526,7 @@ class VncClient extends Events {
 
             if(rect.encoding === encodings.pseudoQemuAudio){
 				this.sendAudio(true);
-				this.sendAudioConfig(2,22050);//todo: add config values for changing this (future: setFrequency(...) to update mid thing)
+				this.sendAudioConfig(this._audioChannels,this._audioFrequency);//todo: future: setFrequency(...) to update mid thing
 			} else if(rect.encoding === encodings.pseudoQemuPointerMotionChange){
 				this._relativePointer=rect.x==0;
 			} else if (rect.encoding === encodings.pseudoCursor) {
@@ -655,6 +658,9 @@ class VncClient extends Events {
         this._version = '';
 
         this._password = '';
+	
+	this._audioChannels=2;
+	this._audioFrequency=22050;
 
         this._handshaked = false;
 

--- a/vncclient.js
+++ b/vncclient.js
@@ -776,7 +776,17 @@ class VncClient extends Events {
         message.writeUInt8(clientMsgTypes.qemuAudio); // Message type
         message.writeUInt8(1, 1); // Submessage Type
         message.writeUInt16BE(enable?0:1, 2); // Operation
+        this._connection.write(message);
+    }
 
+    clientAudioConfig(channels, frequency) {
+        const message = new Buffer(8 + textBuffer.length);
+        message.writeUInt8(clientMsgTypes.qemuAudio); // Message type
+        message.writeUInt8(1, 1); // Submessage Type
+        message.writeUInt16BE(2, 2); // Operation
+        message.writeUInt8(0/*U8*/, 4); // Sample Format
+        message.writeUInt8(channels, 5); // Number of Channels
+        message.writeUInt32BE(frequency, 6); // Frequency
         this._connection.write(message);
     }
 

--- a/vncclient.js
+++ b/vncclient.js
@@ -624,7 +624,7 @@ class VncClient extends Events {
     	    await this._socketBuffer.waitBytes(length);
 
     	    let audioBuffer = [];
-    	    for(let i=0;i<length;i++)audioBuffer.push(this._socketBuffer.readUInt8());
+    	    for(let i=0;i<length/2;i++)audioBuffer.push(this._socketBuffer.readUInt16BE());
 
     	    this._audioData = audioBuffer;
 		}

--- a/vncclient.js
+++ b/vncclient.js
@@ -523,7 +523,9 @@ class VncClient extends Events {
 
             if(rect.encoding === encodings.pseudoQemuAudio){
 				this.sendAudio(true);
-				this.sendAudioConfig(2,22500);
+				this.sendAudioConfig(2,22500);//todo: add config values for changing this (future: setFrequency(...) to update mid thing)
+			} else if(rect.encoding === encodings.pseudoQemuPointerMotionChange){
+				console.log("HYPE: "+JSON.stringify(rect));
 			} else if (rect.encoding === encodings.pseudoCursor) {
                 const dataSize = rect.width * rect.height * (this.pixelFormat.bitsPerPixel / 8);
                 const bitmaskSize = Math.floor((rect.width + 7) / 8) * rect.height;
@@ -618,7 +620,7 @@ class VncClient extends Events {
         if(operation==2){
     	    const length = this._socketBuffer.readUInt32BE();
 
-    	    this._log(`Audio received. Length: ${length}.`);
+    	    //this._log(`Audio received. Length: ${length}.`);
 
     	    await this._socketBuffer.waitBytes(length);
 

--- a/vncclient.js
+++ b/vncclient.js
@@ -771,6 +771,15 @@ class VncClient extends Events {
 
     }
 
+    clientAudio(enable) {
+        const message = new Buffer(8 + textBuffer.length);
+        message.writeUInt8(clientMsgTypes.qemuAudio); // Message type
+        message.writeUInt8(1, 1); // Submessage Type
+        message.writeUInt16BE(enable?0:1, 2); // Operation
+
+        this._connection.write(message);
+    }
+
     /**
      * Print log info
      * @param text

--- a/vncclient.js
+++ b/vncclient.js
@@ -104,7 +104,7 @@ class VncClient extends Events {
      * @param fps {number} - Number of update requests send by second
      */
     changeFps(fps) {
-        if (fps && !Number.isNaN(fps)) {
+        if (!Number.isNaN(fps)) {
             this._fps = Number(fps);
             this._timerInterval = this._fps > 0 ? 1000 / this._fps : 0;
 


### PR DESCRIPTION
use by specifying them in the encodings configuration.

if you want to feel free to implement an event for pointer relative/absolute change, but you can read the value using `client._relativePointer`

audio stream default values if not specified in the initial config are `2` channels and `22050`hz frequency. audio stream will be automatically started if the server says it is supported, and can be stopped with `client.sendAudio(false)`. it can be reconfigured with `client.sendAudioConfig(numChannels, frequency)`, and can be read with `client.on('audioStream',buffer=>{});` where `buffer` is a PCM audio stream. NOTICE: may have issues with only 1 channel because I thiiiink the way it parses the audio stream assumes it as being 2 channels. further tests would be needed to determine if this is the case.

I also fixed `changeFPS(0)` which would result in it thinking it wasn't a number because it checked if `fps` was true which it is not when =`0`

also I noticed that `clientMsgTypes` went unused but values cooresponding to it were used which was weird. I did not fix this in already existing code but used `clientMsgTypes` in my own code. I suggest in e.g. `clientCutText`: `message.writeUInt8(6); // Message type` the `6` be replaced with `clientMsgTypes.cutText`.