### PR TITLE
Support for Apple VNC protocol

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -20,7 +20,8 @@ const consts = {
     versionString: {
         V3_003: 'RFB 003.003\n',
         V3_007: 'RFB 003.007\n',
-        V3_008: 'RFB 003.008\n'
+        V3_008: 'RFB 003.008\n',
+        V3_889: 'RFB 003.889\n'
     },
     encodings: {
         raw: 0,


### PR DESCRIPTION
On MacOS, Apple implemed a VNC Server based on the RFB protocol version `003.889` (undocumented) compatible with RFB `3.8`.
I also added a better handling of `DES` cipher suggested on #8